### PR TITLE
WIP: Add support for "info" assertion level

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ The `errors`, `passed`, and `warnings` arrays are reported as determined by the 
 They are instances of the following form:
 ```javascript
 {
-    type: type,                     // "error" or "warning"
+    type: type,                     // "error", "warning" or "info"
     test: test,                     // xpath test
     simplifiedTest: simplifiedTest, // xpath test with resource values included, if applicable, null otherwise
     description: description,       // schematron description of the test case
@@ -149,7 +149,7 @@ The `ignored` tests are those that resulted in an exception while running (eg. t
 ```javascript
 {
     errorMessage: errorMessage,     // reason for the exception/ignoring the test
-    type: type,                     // "error" or "warning"
+    type: type,                     // "error", "warning" or "info"
     test: test,                     // xpath test
     simplifiedTest: simplifiedTest, // xpath test with resource values included, if applicable, null otherwise
     description: description,       // schematron description of the test case

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -1,5 +1,5 @@
 
-import parseSchematron, { IAssertion, IFunction, IParsedSchematron, IRule } from "./parse-schematron";
+import parseSchematron, { IAssertion, IAssertionLevel, IFunction, IParsedSchematron, IRule } from './parse-schematron'
 import testAssertion, { ITestAssertionError, ITestAssertionResult } from "./test-assertion";
 
 import {
@@ -35,7 +35,7 @@ interface IRuleResult {
     results: ITestAssertionResult[] | ITestAssertionError;
     simplifiedTest: null | string;
     test: string;
-    type: "warning" | "error";
+    type: IAssertionLevel;
 }
 
 interface IRuleIgnored {
@@ -44,11 +44,11 @@ interface IRuleIgnored {
     errorMessage: string;
     simplifiedTest: null | string;
     test: string;
-    type: "warning" | "error";
+    type: IAssertionLevel;
 }
 
 export interface IValidationResult {
-    type: "error" | "warning";
+    type: IAssertionLevel;
     test: string;
     simplifiedTest: string | null;
     description: string;
@@ -62,7 +62,7 @@ export interface IValidationResult {
 }
 
 export interface IIgnoredResult {
-    type: "error" | "warning";
+    type: IAssertionLevel;
     test: string;
     simplifiedTest: string | null;
     patternId: string;


### PR DESCRIPTION
In order to support [a Schematron file that has 3 phases](https://github.com/JATS4R/validator/blob/9536fcbf38d17a586f78babe094d74a705436dfa/schema/1.0/jats4r-level.sch#L36-L61) ("error", "warning" and "info"), with the same assertions in multiple phases, this adds support for an "info" phase and ensures that the phases are collected in increasing order of severity.