### PR TITLE
Add blob as acceptable URL prefix

### DIFF
--- a/src/include-external-document.ts
+++ b/src/include-external-document.ts
@@ -130,7 +130,7 @@ export function loadXML(
     if (prom) {
         return prom;
     }
-    if (/^(?:https?|file):\/\//.test(uri)) {
+    if (/^(?:https?|file|blob):\/\//.test(uri)) {
         prom = options.loadXMLUrl(options, uri);
     } else {
         prom = options.loadXMLFile(options, uri);


### PR DESCRIPTION
This adds `blob` to the regex of URL prefixes, so that URLs created with `window.URL.createObjectURL(blob)` in a browser can be passed in as the `xml` parameter.